### PR TITLE
unify all modals on one consistent design

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -63,12 +63,12 @@
             role="dialog"
             aria-modal="true"
         >
-            <div class="absolute inset-0 bg-slate-950/50 backdrop-blur-sm" @click="confirming = false"></div>
+            <div class="absolute inset-0 bg-slate-950/80" @click="confirming = false"></div>
 
             <div
                 x-show="confirming"
                 x-transition.scale.origin.center
-                class="relative w-full max-w-sm rounded-3xl bg-white p-7 text-center shadow-2xl"
+                class="relative w-full max-w-sm rounded-2xl bg-white p-7 text-center shadow-2xl"
             >
                 <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-sky-100">
                     <svg class="h-7 w-7 text-sky-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -58,33 +58,33 @@ $contentOverflowClass = [
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
-    class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
+    class="fixed inset-0 z-50 overflow-y-auto"
     style="display: {{ $show ? 'block' : 'none' }};"
 >
     <div
         x-show="show"
-        class="fixed inset-0 transform transition-all"
-        x-on:click="show = false"
+        class="fixed inset-0 bg-slate-950/80 transform transition-all"
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0"
         x-transition:enter-end="opacity-100"
         x-transition:leave="ease-in duration-200"
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
-    >
-        <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
-    </div>
+        aria-hidden="true"
+    ></div>
 
-    <div
-        x-show="show"
-        class="mb-6 bg-white rounded-lg {{ $contentOverflowClass }} shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
-        x-transition:enter="ease-out duration-300"
-        x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-        x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
-        x-transition:leave="ease-in duration-200"
-        x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
-        x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-    >
-        {{ $slot }}
+    <div class="relative flex min-h-screen items-center justify-center px-4 py-6" x-on:click.self="show = false">
+        <div
+            x-show="show"
+            class="relative w-full bg-white rounded-2xl {{ $contentOverflowClass }} shadow-2xl transform transition-all sm:mx-auto {{ $maxWidth }}"
+            x-transition:enter="ease-out duration-300"
+            x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+            x-transition:leave="ease-in duration-200"
+            x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+            x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        >
+            {{ $slot }}
+        </div>
     </div>
 </div>

--- a/resources/views/components/popup-alert.blade.php
+++ b/resources/views/components/popup-alert.blade.php
@@ -43,12 +43,12 @@
         role="dialog"
         aria-modal="true"
     >
-        <div class="absolute inset-0 bg-slate-950/50 backdrop-blur-sm" @click="open = false"></div>
+        <div class="absolute inset-0 bg-slate-950/80" @click="open = false"></div>
 
         <div
             x-show="open"
             x-transition.scale.origin.center
-            class="relative w-full max-w-sm rounded-3xl bg-white p-7 text-center shadow-2xl"
+            class="relative w-full max-w-sm rounded-2xl bg-white p-7 text-center shadow-2xl"
         >
             <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full {{ $p['iconBg'] }}">
                 <svg class="h-7 w-7 {{ $p['accent'] }}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/resources/views/incidents/edit.blade.php
+++ b/resources/views/incidents/edit.blade.php
@@ -209,7 +209,7 @@
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closePreview()"></div>
-                <div class="relative w-full max-w-5xl overflow-hidden rounded-3xl bg-white shadow-2xl">
+                <div class="relative w-full max-w-5xl overflow-hidden rounded-2xl bg-white shadow-2xl">
                     <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4">
                         <h3 class="text-base font-semibold text-slate-900" x-text="previewLabel || 'Proof image preview'"></h3>
                         <button

--- a/resources/views/incidents/index.blade.php
+++ b/resources/views/incidents/index.blade.php
@@ -422,7 +422,7 @@
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closeExportPreview()"></div>
-                <div class="relative w-full max-w-6xl overflow-hidden bg-white shadow-2xl rounded-3xl">
+                <div class="relative w-full max-w-6xl overflow-hidden bg-white shadow-2xl rounded-2xl">
                     <div class="flex flex-wrap items-center justify-between gap-3 px-5 py-4 border-b border-slate-200">
                         <h3 class="text-base font-semibold text-slate-900">Incident Report Preview</h3>
                         <div class="flex flex-wrap items-center gap-2">
@@ -467,7 +467,7 @@
                 x-cloak
                 x-show="excelConfirmOpen"
                 x-on:keydown.escape.window="closeExcelConfirm()"
-                class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-6 bg-slate-950/70"
+                class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-6 bg-slate-950/80"
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closeExcelConfirm()"></div>
@@ -500,7 +500,7 @@
                 x-cloak
                 x-show="pdfConfirmOpen"
                 x-on:keydown.escape.window="closePdfConfirm()"
-                class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-6 bg-slate-950/70"
+                class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-6 bg-slate-950/80"
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closePdfConfirm()"></div>
@@ -536,7 +536,7 @@
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closePreview()"></div>
-                <div class="relative w-full max-w-5xl overflow-hidden bg-white shadow-2xl rounded-3xl">
+                <div class="relative w-full max-w-5xl overflow-hidden bg-white shadow-2xl rounded-2xl">
                     <div class="flex items-center justify-between px-5 py-4 border-b border-slate-200">
                         <h3 class="text-base font-semibold text-slate-900" x-text="previewLabel || 'Proof image preview'"></h3>
                         <button

--- a/resources/views/incidents/show.blade.php
+++ b/resources/views/incidents/show.blade.php
@@ -221,7 +221,7 @@
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closePreview()"></div>
-                <div class="relative w-full max-w-5xl overflow-hidden bg-white shadow-2xl rounded-3xl">
+                <div class="relative w-full max-w-5xl overflow-hidden bg-white shadow-2xl rounded-2xl">
                     <div class="flex items-center justify-between px-5 py-4 border-b border-slate-200">
                         <h3 class="text-base font-semibold text-slate-900" x-text="previewLabel || 'Proof image preview'"></h3>
                         <button

--- a/resources/views/password-resets/index.blade.php
+++ b/resources/views/password-resets/index.blade.php
@@ -35,12 +35,12 @@
                     role="dialog"
                     aria-modal="true"
                 >
-                    <div class="absolute inset-0 bg-slate-950/50 backdrop-blur-sm" @click="open = false"></div>
+                    <div class="absolute inset-0 bg-slate-950/80" @click="open = false"></div>
 
                     <div
                         x-show="open"
                         x-transition.scale.origin.center
-                        class="relative w-full max-w-md rounded-3xl bg-white p-7 text-center shadow-2xl"
+                        class="relative w-full max-w-md rounded-2xl bg-white p-7 text-center shadow-2xl"
                     >
                         <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-amber-100">
                             <svg class="h-7 w-7 text-amber-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -31,12 +31,12 @@
                     role="dialog"
                     aria-modal="true"
                 >
-                    <div class="absolute inset-0 bg-slate-950/50 backdrop-blur-sm" @click="open = false"></div>
+                    <div class="absolute inset-0 bg-slate-950/80" @click="open = false"></div>
 
                     <div
                         x-show="open"
                         x-transition.scale.origin.center
-                        class="relative w-full max-w-md rounded-3xl bg-white p-7 text-center shadow-2xl"
+                        class="relative w-full max-w-md rounded-2xl bg-white p-7 text-center shadow-2xl"
                     >
                         <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-amber-100">
                             <svg class="h-7 w-7 text-amber-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/resources/views/visitors/index.blade.php
+++ b/resources/views/visitors/index.blade.php
@@ -946,7 +946,7 @@
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closeExportPreview()"></div>
-                <div class="relative w-full max-w-6xl overflow-hidden bg-white shadow-2xl rounded-3xl">
+                <div class="relative w-full max-w-6xl overflow-hidden bg-white shadow-2xl rounded-2xl">
                     <div class="flex flex-wrap items-center justify-between gap-3 px-5 py-4 border-b border-slate-200">
                         <h3 class="text-base font-semibold text-slate-900">Visitor Report Preview</h3>
                         <div class="flex flex-wrap items-center gap-2">
@@ -991,7 +991,7 @@
                 x-cloak
                 x-show="excelConfirmOpen"
                 x-on:keydown.escape.window="closeExcelConfirm()"
-                class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-6 bg-slate-950/70"
+                class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-6 bg-slate-950/80"
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closeExcelConfirm()"></div>
@@ -1024,7 +1024,7 @@
                 x-cloak
                 x-show="pdfConfirmOpen"
                 x-on:keydown.escape.window="closePdfConfirm()"
-                class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-6 bg-slate-950/70"
+                class="fixed inset-0 z-[60] flex items-center justify-center px-4 py-6 bg-slate-950/80"
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closePdfConfirm()"></div>

--- a/resources/views/visitors/show.blade.php
+++ b/resources/views/visitors/show.blade.php
@@ -201,7 +201,7 @@
                 style="display: none;"
             >
                 <div class="absolute inset-0" @click="closePreview()"></div>
-                <div class="relative w-full max-w-4xl overflow-hidden bg-white shadow-2xl rounded-3xl">
+                <div class="relative w-full max-w-4xl overflow-hidden bg-white shadow-2xl rounded-2xl">
                     <div class="flex items-center justify-between px-5 py-4 border-b border-slate-200">
                         <h3 class="text-base font-semibold text-slate-900" x-text="previewLabel || 'Visitor ID photo preview'"></h3>
                         <button


### PR DESCRIPTION
Standardize modal chrome across the app: slate-950/80 backdrop,
centered, rounded-2xl, shadow-2xl. Update the x-modal component
and align all inline modals to match.